### PR TITLE
Compatible with macos 14

### DIFF
--- a/AssisChat/Features/Chat/ChatsView.swift
+++ b/AssisChat/Features/Chat/ChatsView.swift
@@ -115,10 +115,16 @@ private struct ChatList: View {
                     Text("Go to set chat source")
                 }
                 #else
-                Button {
-                    MacOSSettingsView.open()
-                } label: {
-                    Text("Go to set chat source")
+                if #available(macOS 14, *) {
+                    SettingsLink(label: {
+                        Text("Go to set chat source")
+                    })
+                } else {
+                    Button {
+                        MacOSSettingsView.open()
+                    } label: {
+                        Text("Go to set chat source")
+                    }
                 }
                 #endif
             }

--- a/AssisChat/Features/Chat/ChatsView.swift
+++ b/AssisChat/Features/Chat/ChatsView.swift
@@ -44,10 +44,16 @@ struct ChatsView: View {
                         Label("SETTINGS", systemImage: "gearshape")
                     }
                     #else
-                    Button {
-                        MacOSSettingsView.open()
-                    } label: {
-                        Label("SETTINGS", systemImage: "gearshape")
+                    if #available(macOS 14, *) {
+                        SettingsLink(label: {
+                            Label("SETTINGS", systemImage: "gearshape")
+                        })
+                    } else {
+                        Button {
+                            MacOSSettingsView.open()
+                        } label: {
+                            Label("SETTINGS", systemImage: "gearshape")
+                        }
                     }
                     #endif
                 }


### PR DESCRIPTION
fix "Please use SettingsLink for opening the Settings scene." on macOS 14.3